### PR TITLE
fix: handle starting slash on opa path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treedom/mercurius-auth-opa",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "lib/index.js",
   "scripts": {
     "test": "borp",

--- a/src/OpenPolicyAgentClient.ts
+++ b/src/OpenPolicyAgentClient.ts
@@ -42,7 +42,11 @@ export class OpenPolicyAgentClient<TCache extends Cache> {
     resource: string,
     input?: unknown
   ): Promise<TResponse> {
-    const resourcePath = resource.replace(/\./gi, '/')
+    let resourcePath = resource.replace(/\./gi, '/')
+
+    if (!resourcePath.startsWith('/')) {
+      resourcePath = `/${resourcePath}`
+    }
 
     const cacheKey = getCacheKey(resourcePath, input)
     const cached = this.cache?.get(cacheKey) as TResponse | undefined
@@ -52,7 +56,7 @@ export class OpenPolicyAgentClient<TCache extends Cache> {
     }
 
     const res = await request(
-      `${this.url}/${this.opaVersion}/data/${resourcePath}`,
+      `${this.url}/${this.opaVersion}/data${resourcePath}`,
       {
         method: this.method,
         body: input ? JSON.stringify({ input }) : undefined,

--- a/src/OpenPolicyAgentClient.ts
+++ b/src/OpenPolicyAgentClient.ts
@@ -44,8 +44,8 @@ export class OpenPolicyAgentClient<TCache extends Cache> {
   ): Promise<TResponse> {
     let resourcePath = resource.replace(/\./gi, '/')
 
-    if (!resourcePath.startsWith('/')) {
-      resourcePath = `/${resourcePath}`
+    if (resourcePath.startsWith('/')) {
+      resourcePath = resourcePath.substring(1, resourcePath.length)
     }
 
     const cacheKey = getCacheKey(resourcePath, input)
@@ -56,7 +56,7 @@ export class OpenPolicyAgentClient<TCache extends Cache> {
     }
 
     const res = await request(
-      `${this.url}/${this.opaVersion}/data${resourcePath}`,
+      `${this.url}/${this.opaVersion}/data/${resourcePath}`,
       {
         method: this.method,
         body: input ? JSON.stringify({ input }) : undefined,

--- a/test/opaAuthPlugin.test.ts
+++ b/test/opaAuthPlugin.test.ts
@@ -233,4 +233,3 @@ ping(message: String!): String! @opa(path: "/query/ping", options: { bar: "foo",
     arr: [{ a: 'b' }, { c: 'd' }],
   })
 })
-


### PR DESCRIPTION
If you define the opa directive with path `/path/subpath`, the plugin doesn't handle correctly the generation of the opa url. With this PR, the plugin check if starting slash is already present, if not, it will add.